### PR TITLE
Shorten string that is used in the highlighter to make slightly more efficient 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,20 +141,5 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
         </dependency>
-
-
-        <!--LuaJ JME-->
-        <dependency>
-            <groupId>org.luaj</groupId>
-            <artifactId>luaj-jme</artifactId>
-            <version>3.0.1</version>
-        </dependency>
-
-        <!--LuaJ JSE-->
-        <dependency>
-            <groupId>org.luaj</groupId>
-            <artifactId>luaj-jse</artifactId>
-            <version>3.0.1</version>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
         </dependency>
 
 
-
         <!--  JHighlight  -->
         <dependency>
             <groupId>org.apache.tika</groupId>
@@ -141,6 +140,21 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
+        </dependency>
+
+
+        <!--LuaJ JME-->
+        <dependency>
+            <groupId>org.luaj</groupId>
+            <artifactId>luaj-jme</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <!--LuaJ JSE-->
+        <dependency>
+            <groupId>org.luaj</groupId>
+            <artifactId>luaj-jse</artifactId>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/uddernetworks/mspaint/highlighter/LetterFormatter.java
+++ b/src/main/java/com/uddernetworks/mspaint/highlighter/LetterFormatter.java
@@ -20,21 +20,12 @@ public class LetterFormatter {
             if (letters.size() <= i) continue;
             List<Letter> letterRow = letters.get(i);
 
-            String line = lines[i].substring(0, lines[i].length() - 1).trim();
+            String line = lines[i].trim();
 
             String[] nums = line.split(",");
 
-            int index = 0;
-            for (int i2 = 0; i2 < nums.length; i2++) {
-                int r = Integer.valueOf(nums[i2]);
-                i2++;
-                int g = Integer.valueOf(nums[i2]);
-                i2++;
-                int b = Integer.valueOf(nums[i2]);
-
-                letterRow.get(index).setColor(new Color(r, g, b));
-                index++;
-            }
+            for (int j = 0; j < nums.length; j++)
+                letterRow.get(j).setColor(new Color(Integer.valueOf(nums[j])));
         }
     }
 }

--- a/src/main/java/com/uddernetworks/mspaint/languages/java/JavaLanguageHighlighter.java
+++ b/src/main/java/com/uddernetworks/mspaint/languages/java/JavaLanguageHighlighter.java
@@ -12,23 +12,23 @@ public class JavaLanguageHighlighter implements LanguageHighlighter {
     private String getCssClass(int style) {
         switch (style) {
             case 1:
-                return "000,000,000,"; // plain
+                return 0x000000 + ","; // plain
             case 2:
-                return "000,000,000,"; // keyword
+                return 0x000000 + ","; // keyword
             case 3:
-                return "000,044,221,"; // type
+                return 0x002cdd + ","; // type
             case 4:
-                return "000,124,031,"; // operator
+                return 0x007c1f + ","; // operator
             case 5:
-                return "000,033,255,"; // separator
+                return 0x0021ff + ","; // separator
             case 6:
-                return "188,000,000,"; // literal
+                return 0xbc0000 + ","; // literal
             case 7:
-                return "147,147,147,"; // comment
+                return 0x939393 + ","; // comment
             case 8:
-                return "147,147,147,"; // javadoc comment
+                return 0x939393 + ","; // javadoc comment
             case 9:
-                return "147,147,147,"; // javadoc tag
+                return 0x939393 + ","; // javadoc tag
             default:
                 return null;
         }


### PR DESCRIPTION
Pretty simple, just went from using the format `"rrr,ggg,bbb,"` to `0xRRGGBB + ","` 